### PR TITLE
SYSTEM.CSRRx operations

### DIFF
--- a/OberonRV/RVOB.Mod
+++ b/OberonRV/RVOB.Mod
@@ -437,15 +437,15 @@ BEGIN
   topScope := NIL; OpenScope; topScope.next := system; universe := topScope;
   
   system := NIL;  (* initialize "unsafe" pseudo-module SYSTEM*)
-  enter("H", SFunc, intType, 201);     (*functions*)
-  enter("COND", SFunc, boolType, 191);
+  enter("CSRRC", SFunc, intType, 212);     (*functions*)
+  enter("CSRRS", SFunc, intType, 202);
+  enter("CSRRW", SFunc, intType, 192);
   enter("SIZE", SFunc, intType, 181);
   enter("ADR", SFunc, intType, 171);
   enter("VAL", SFunc, intType, 162);
   enter("REG", SFunc, intType, 151);
   enter("BIT", SFunc, boolType, 142);
   enter("LDREG", SProc, noType, 142);  (*procedures*)
-  enter("LDPSR", SProc, noType, 131);
   enter("COPY", SProc, noType, 123);
   enter("PUT", SProc, noType, 112);
   enter("GET", SProc, noType, 102);

--- a/OberonRV/RVOG.Mod
+++ b/OberonRV/RVOG.Mod
@@ -1741,16 +1741,19 @@ END Adr;
 PROCEDURE CSRop*(op: INTEGER; VAR x, y: Item);
 BEGIN
   ASSERT(x.mode = ORB.Const);
-  ASSERT((0 <= x.a) & (x.a < 4096));
-  IF (y.mode = ORB.Const) & (0 <= y.a) & (y.a < 32) THEN
-    put(RVAssem.fmtI(73H, op+5, RH, y.a, x.a));
-    x.mode := Reg;
-    x.r := RH; incR
+  IF (x.a < 0) OR  (4096 <= x.a) THEN
+    ORS.Mark("CSR must lie between 0000H and 0FFFH inclusive.");
   ELSE
-    load(y);
-    ASSERT(y.mode = Reg);
-    put(RVAssem.fmtI(73H, op+1, y.r, y.r, x.a));
-    x := y
+    IF (y.mode = ORB.Const) & (0 <= y.a) & (y.a < 32) THEN
+      put(RVAssem.fmtI(73H, op+5, RH, y.a, x.a));
+      x.mode := Reg;
+      x.r := RH; incR
+    ELSE
+      load(y);
+      ASSERT(y.mode = Reg);
+      put(RVAssem.fmtI(73H, op+1, y.r, y.r, x.a));
+      x := y
+    END
   END
 END CSRop;
 

--- a/OberonRV/RVOG.Mod
+++ b/OberonRV/RVOG.Mod
@@ -1738,6 +1738,22 @@ BEGIN
   END
 END Adr;
 
+PROCEDURE CSRop*(op: INTEGER; VAR x, y: Item);
+BEGIN
+  ASSERT(x.mode = ORB.Const);
+  ASSERT((0 <= x.a) & (x.a < 4096));
+  IF (y.mode = ORB.Const) & (0 <= y.a) & (y.a < 32) THEN
+    put(RVAssem.fmtI(73H, op+5, RH, y.a, x.a));
+    x.mode := Reg;
+    x.r := RH; incR
+  ELSE
+    load(y);
+    ASSERT(y.mode = Reg);
+    put(RVAssem.fmtI(73H, op+1, y.r, y.r, x.a));
+    x := y
+  END
+END CSRop;
+
 PROCEDURE Open*(v: INTEGER);
 BEGIN pc := 0; tdx := 0; strx := 0; RH := firstReg; fixorgP := 0; fixorgD := 0; fixorgT := 0; check := v # 0; version := v;
   IF v = 0 THEN pc := 8 END

--- a/OberonRV/RVOP.Mod
+++ b/OberonRV/RVOP.Mod
@@ -61,6 +61,13 @@ END RoundUp;
     IF x.type.form # ORB.Int THEN ORS.Mark("not Integer"); x.type := ORB.intType END
   END CheckInt;
 
+  PROCEDURE CheckIntOrSet(VAR x: RVOG.Item);
+  BEGIN
+    IF (x.type.form # ORB.Int) & (x.type.form # ORB.Set) THEN
+      ORS.Mark("neither integer nor set"); x.type := ORB.intType
+    END
+  END CheckIntOrSet;
+
   PROCEDURE CheckReal(VAR x: RVOG.Item);
   BEGIN
     IF x.type.form # ORB.Real THEN ORS.Mark("not Real"); x.type := ORB.realType END
@@ -280,6 +287,8 @@ END RoundUp;
         IF x.mode = ORB.Typ THEN RVOG.MakeConstItem(x, ORB.intType, x.type.size)
         ELSE ORS.Mark("must be a type")
         END
+      ELSIF fct IN {19, 20, 21} THEN
+        CheckConst(x); CheckInt(x); CheckIntOrSet(y); RVOG.CSRop(fct-19, x, y);
       ELSIF fct = 19 THEN (*COND*) ORS.Mark("no COND")
       ELSIF fct = 20 THEN (*H*) ORS.Mark("no H")
       END ;


### PR DESCRIPTION
Implement three new SYSTEM standard functions:

  x := SYSTEM.CSRRW(csr, y);
  x := SYSTEM.CSRRS(csr, y);
  x := SYSTEM.CSRRC(csr, y);

csr MUST be an integer constant, or a CONST alias.

y can be any expression that evaluates to an integer or a set.

Set notation is particularly useful for managing interrupts.
Integers are useful for working with addresses.
Either integers or sets can be used for accessing specific sub-fields.

The result of these functions is the _original_ value of the CSR.

See RISC-V Privileged Instruction manual for semantics on the CSRRx
instructions.

Fixes #10 
